### PR TITLE
Support for converting screen x,y pixel to voxel

### DIFF
--- a/library/src/main/java/wannabe/Camera.kt
+++ b/library/src/main/java/wannabe/Camera.kt
@@ -25,4 +25,13 @@ class Camera(
     translated.z = toTranslate.z - position.z
     return translated
   }
+
+  // TODO wrong in so many ways. Where's the 25 come from?
+  // size of the demo app playfield maybe?
+  fun reverseTranslate(toTranslate: Position): Translation {
+    translated.x = toTranslate.x + position.x - 25
+    translated.y = toTranslate.y + position.y - 25
+    translated.z = toTranslate.z + position.z
+    return translated
+  }
 }

--- a/library/src/main/java/wannabe/Pos.kt
+++ b/library/src/main/java/wannabe/Pos.kt
@@ -1,12 +1,12 @@
 package wannabe
 
 /**
- * Parent interface that allows easy comparison of [Position] and [Translation].
- * TODO delete this class -- consider a special class that somehow hides mutability
+ * Simple interface that allows easy comparison of [Position] and [Translation].
  */
 interface Pos {
-  fun x(): Int
-  fun y(): Int
-  fun z(): Int
+  val x: Int
+  val y: Int
+  val z: Int
   val isZero: Boolean
+      get() = x == 0 && y == 0 && z == 0
 }

--- a/library/src/main/java/wannabe/Position.kt
+++ b/library/src/main/java/wannabe/Position.kt
@@ -5,18 +5,10 @@ package wannabe
  * Produces the same hashcode and equals results as a Translation for the same values of x, y, and z.
  */
 data class Position(
-  val x: Int = 0,
-  val y: Int = 0,
-  val z: Int = 0
+  override val x: Int = 0,
+  override val y: Int = 0,
+  override val z: Int = 0
 ) : Pos {
-  override fun x(): Int = x
-
-  override fun y(): Int = y
-
-  override fun z(): Int = z
-
-  override val isZero: Boolean
-    get() = x == 0 && y == 0 && z == 0
 
   override fun hashCode(): Int {
     val prime = 31
@@ -29,9 +21,7 @@ data class Position(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other is Position) {
-      return x == other.x && y == other.y && z == other.z
-    } else if (other is Translation) {
+    if (other is Pos) {
       return x == other.x && y == other.y && z == other.z
     }
     return false

--- a/library/src/main/java/wannabe/Translation.kt
+++ b/library/src/main/java/wannabe/Translation.kt
@@ -5,27 +5,28 @@ package wannabe
  * results as a Position for the same values of x, y, and z.
  */
 data class Translation(
-  var x: Int = 0,
-  var y: Int = 0,
-  var z: Int = 0
+  override var x: Int = 0,
+  override var y: Int = 0,
+  override var z: Int = 0
 ) : Pos {
 
-  constructor(position: Translation) : this(
-      x = position.x,
-      y = position.y,
-      z = position.z
+  constructor(pos: Pos) : this(
+      x = pos.x,
+      y = pos.y,
+      z = pos.z
   )
 
-  constructor(position: Position) : this(
-      x = position.x,
-      y = position.y,
-      z = position.z
-  )
-
-  fun add(offset: Translation): Translation {
+  fun add(offset: Pos): Translation {
     x += offset.x
     y += offset.y
     z += offset.z
+    return this
+  }
+
+  fun subtract(offset: Pos): Translation {
+    x -= offset.x
+    y -= offset.y
+    z -= offset.z
     return this
   }
 
@@ -33,17 +34,21 @@ data class Translation(
     return Position(x, y, z)
   }
 
-  fun set(position: Translation): Translation {
-    x = position.x
-    y = position.y
-    z = position.z
+  fun set(pos: Pos): Translation {
+    x = pos.x
+    y = pos.y
+    z = pos.z
     return this
   }
-
-  fun set(position: Position): Translation {
-    x = position.x
-    y = position.y
-    z = position.z
+  
+  fun set(
+    newX: Int = 0,
+    newY: Int = 0,
+    newZ: Int = 0
+  ): Translation {
+    x = newX
+    y = newY
+    z = newZ
     return this
   }
 
@@ -53,21 +58,6 @@ data class Translation(
     z = 0
     return this
   }
-
-  override fun x(): Int {
-    return x
-  }
-
-  override fun y(): Int {
-    return y
-  }
-
-  override fun z(): Int {
-    return z
-  }
-
-  override val isZero: Boolean
-    get() = x == 0 && y == 0 && z == 0
 
   override fun hashCode(): Int {
     val prime = 31
@@ -80,9 +70,7 @@ data class Translation(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other is Translation) {
-      return x == other.x && y == other.y && z == other.z
-    } else if (other is Position) {
+    if (other is Pos) {
       return x == other.x && y == other.y && z == other.z
     }
     return false

--- a/library/src/main/java/wannabe/Voxel.kt
+++ b/library/src/main/java/wannabe/Voxel.kt
@@ -12,7 +12,6 @@ data class Voxel(
     y: Int,
     z: Int,
     value: Int
-  ) : this(Position(x, y, z), value) {
-  }
+  ) : this(Position(x, y, z), value)
 
 }

--- a/library/src/main/java/wannabe/grid/RotateGrid.kt
+++ b/library/src/main/java/wannabe/grid/RotateGrid.kt
@@ -1,6 +1,7 @@
 package wannabe.grid
 
 import wannabe.Voxel
+import wannabe.Position
 import wannabe.grid.iterators.RotatingIterator
 import wannabe.grid.iterators.RotationDegrees
 
@@ -26,11 +27,13 @@ class RotateGrid(
   fun setRotate(
     xDegrees: Int,
     yDegrees: Int,
-    zDegrees: Int
+    zDegrees: Int,
+    around: Position = Position.Companion.ZERO
   ) {
     rotation.x = xDegrees
     rotation.y = yDegrees
     rotation.z = zDegrees
+    rotation.around = around
     dirty = true
   }
 

--- a/library/src/main/java/wannabe/grid/SimpleGrid.kt
+++ b/library/src/main/java/wannabe/grid/SimpleGrid.kt
@@ -25,7 +25,6 @@ class SimpleGrid(
 
   private val positionToVoxels: MutableMap<Pos, Voxel> = TreeMap(zxyIncreasing)
   private val neighborCache: MutableMap<Voxel, AllNeighbors?> = mutableMapOf()
-  private val translation = Translation(0, 0, 0)
 
   override var isDirty = false
     private set
@@ -115,76 +114,18 @@ class SimpleGrid(
     return !theNeighbors.isSurrounded || !bounds.containsAll(voxel.position, theNeighbors)
   }
 
-  private fun exportNoHidden(
-    grid: MutableGrid,
-    bounds: Bounds
-  ) {
-    if (translation.isZero) {
-      // We can skip cloning and translation.
-      for (voxel in positionToVoxels.values) {
-        if (bounds.contains(voxel.position)
-            && notSurroundedInBounds(bounds, voxel)
-        ) {
-          grid.put(voxel)
-        }
-      }
-      return
-    }
-
-    // Otherwise, we have to translate all the things.
-    val workhorse = Translation(0, 0, 0)
-    for (voxel in positionToVoxels.values) {
-      workhorse.set(voxel.position)
-          .add(translation)
-      if (bounds.contains(workhorse)
-          && notSurroundedInBounds(bounds, voxel)
-      ) {
-        // TODO double check if we need to handle translation with bounds
-        grid.put(Voxel(workhorse.asPosition(), voxel.value))
-      }
-    }
-  }
-
-  // TODO this is a bit of an ugly near-duplication, but seems good for clarity and perf.
-  // TODO consider if this should just be the api instead of the bool param.
-  private fun exportWithHidden(
-    grid: MutableGrid,
-    bounds: Bounds
-  ) {
-    if (translation.isZero) {
-      // We can skip cloning and translation.
-      for (voxel in positionToVoxels.values) {
-        if (bounds.contains(voxel.position)) {
-          grid.put(voxel)
-        }
-      }
-      return
-    }
-
-    // Otherwise, we have to translate all the things.
-    val workhorse = Translation(0, 0, 0)
-    for ((position, value) in positionToVoxels.values) {
-      workhorse.set(position)
-          .add(translation)
-      if (bounds.contains(workhorse)) {
-        // TODO double check if we need to handle translation with bounds
-        grid.put(Voxel(workhorse.asPosition(), value))
-      }
-    }
-  }
-
   companion object {
     /** Sorts by Z increasing then X increasing then Y increasing.  */
     private val zxyIncreasing = Comparator { o1: Pos, o2: Pos ->
-        val zCmp = o1.z() - o2.z()
+        val zCmp = o1.z - o2.z
         if (zCmp != 0) {
           return@Comparator zCmp
         }
-        val xCmp = o1.x() - o2.x()
+        val xCmp = o1.x - o2.x
         if (xCmp != 0) {
           return@Comparator xCmp
         }
-        o1.y() - o2.y()
+        o1.y - o2.y
       }
   }
 }

--- a/library/src/main/java/wannabe/grid/SingleGrid.kt
+++ b/library/src/main/java/wannabe/grid/SingleGrid.kt
@@ -1,0 +1,24 @@
+package wannabe.grid
+
+import wannabe.Voxel
+import wannabe.grid.iterators.SingleIterator
+
+/** A Grid that has a single voxel in it. */
+class SingleGrid(
+  private val name: String,
+  var voxel: Voxel = Voxel(0, 0, 0, 0)
+) : Grid {
+
+  private val noNeighbors = AllNeighbors()
+
+  override fun iterator(): Iterator<Voxel> = SingleIterator(voxel)
+
+  override val isDirty: Boolean = true // TODO just implement for real
+
+  override val size: Int = 1
+
+  override fun neighbors(voxel: Voxel): AllNeighbors = noNeighbors
+
+  override fun toString(): String = "$name single"
+
+}

--- a/library/src/main/java/wannabe/grid/SparseArrayGrid.kt
+++ b/library/src/main/java/wannabe/grid/SparseArrayGrid.kt
@@ -160,11 +160,11 @@ class SparseArrayGrid(
         if (zCmp != 0) {
           return@Comparator zCmp
         }
-        val xCmp = o1.position.x() - o2.position.x()
+        val xCmp = o1.position.x - o2.position.x
         if (xCmp != 0) {
           xCmp
         } else {
-          o1.position.y() - o2.position.y()
+          o1.position.y - o2.position.y
         }
       }
   }

--- a/library/src/main/java/wannabe/grid/iterators/EmptyIterator.kt
+++ b/library/src/main/java/wannabe/grid/iterators/EmptyIterator.kt
@@ -2,11 +2,8 @@ package wannabe.grid.iterators
 
 import java.util.NoSuchElementException
 
-class EmptyIterator<T> : MutableIterator<T> {
+class EmptyIterator<T> : Iterator<T> {
   override fun hasNext(): Boolean = false
 
   override fun next(): T = throw NoSuchElementException("Empty iterator has no elements")
-
-  override fun remove() =
-    throw UnsupportedOperationException("Empty iterator has nothing to remove")
 }

--- a/library/src/main/java/wannabe/grid/iterators/SingleIterator.kt
+++ b/library/src/main/java/wannabe/grid/iterators/SingleIterator.kt
@@ -1,0 +1,18 @@
+package wannabe.grid.iterators
+
+import java.util.NoSuchElementException
+
+class SingleIterator<T>(
+  val single: T
+) : Iterator<T> {
+  var used = false
+
+  override fun hasNext(): Boolean = !used
+
+  override fun next(): T = if (used) {
+      throw NoSuchElementException("Single iterator has no more elements") 
+    } else {
+      used = true
+      single
+    }
+}

--- a/library/src/main/java/wannabe/projection/Projection.kt
+++ b/library/src/main/java/wannabe/projection/Projection.kt
@@ -8,9 +8,10 @@ import wannabe.Projected
 interface Projection {
   /**
    * Resolves a [Position] to a two-dimensional location relative to the specified
-   * [Camera] with a height-0 size of `pixelSize`.  Projections should honor
-   * [Camera.uiPosition] to allow the UI to render voxels appropriately.
-   * Implementations may reuse the returned instance for performance.
+   * [Camera] with a height-0 size of `pixelSize` (other heights may have other 
+   * relative sizes).  Projections should honor [Camera.uiPosition] to allow the
+   * UI to render voxels appropriately. Implementations may reuse the returned
+   * [Projected] instance for performance.
    */
   fun project(
     camera: Camera,

--- a/library/src/main/java/wannabe/util/SampleGrids.kt
+++ b/library/src/main/java/wannabe/util/SampleGrids.kt
@@ -20,6 +20,27 @@ import kotlin.math.hypot
 import kotlin.math.sin
 
 object SampleGrids {
+  fun originGrid(): Grid {
+    val grid: MutableGrid = SimpleGrid("Origin grid at z=0")
+    grid.put(Voxel(0, 0, 0, 0xFFEEDD))
+    grid.put(Voxel(-1, 0, 0, 0xEEDDCC))
+    grid.put(Voxel(1, 0, 0, 0xEEDDCC))
+    grid.put(Voxel(0, -1, 0, 0xEEDDCC))
+    grid.put(Voxel(0, 1, 0, 0xEEDDCC))
+
+    grid.put(Voxel(-5, 0, 0, 0xDDCCBB))
+    grid.put(Voxel(5, 0, 0, 0xDDCCBB))
+    grid.put(Voxel(0, -5, 0, 0xDDCCBB))
+    grid.put(Voxel(0, 5, 0, 0xDDCCBB))
+
+    grid.put(Voxel(-10, 0, 0, 0xCCBBAA))
+    grid.put(Voxel(10, 0, 0, 0xCCBBAA))
+    grid.put(Voxel(0, -10, 0, 0xCCBBAA))
+    grid.put(Voxel(0, 10, 0, 0xCCBBAA))
+
+    return grid
+  }
+
   /** Grid stretching 30x30 with voxels every 10 along the edge, and 600 random voxels.  */
   fun randomGrid(): Grid {
     val grid: MutableGrid = SimpleGrid("random sparse 30x30")
@@ -240,7 +261,7 @@ object SampleGrids {
     colorMap['H'] = 0xdb450f // Dark brown
     val grid = SimpleGrid("link")
     fromTextMap(
-        grid, Position(0, 0, 40), """
+        grid, Position(0, 0, 0), """
    .....GGGGGG....
    ....GGGGGGGG...
    ..S.GHHHHHHG.S.
@@ -270,9 +291,10 @@ object SampleGrids {
     colorMap['@'] = 0x444444 // Gray
     colorMap['@'] = 0xbbbbbb // Gray
     colorMap['y'] = 0xaaaa00 // Yellow
+    colorMap['.'] = 0xffffff // White
     val frame = SimpleGrid("morbo")
     fromTextMap(
-        frame, Position(0, 0, 40), """
+        frame, Position(0, 0, 0), """
    ...........................................................
    ......**...................................................
    .....**.............................*.......*..............
@@ -467,6 +489,7 @@ object SampleGrids {
   }
 
   val GRIDS = listOf(
+          originGrid(),
           neighborTest(),
           testBed(),
           HouseVignette().buildHouse(),
@@ -477,7 +500,8 @@ object SampleGrids {
           towers(),
           fullRandomGrid(),
           randomGrid(),
-          hollowCube(20, 0x21ffff)
+          hollowCube(20, 0x21ffff),
+          morboCat()
       )
 
   fun next(current: Grid): Grid {

--- a/swing_demo/src/main/java/wannabe/swing/sample/SwingWannabe.kt
+++ b/swing_demo/src/main/java/wannabe/swing/sample/SwingWannabe.kt
@@ -2,10 +2,12 @@ package wannabe.swing.sample
 
 import wannabe.Camera
 import wannabe.Translation
+import wannabe.Voxel
 import wannabe.grid.CachingGrid
 import wannabe.grid.Grid
 import wannabe.grid.GroupGrid
 import wannabe.grid.RotateGrid
+import wannabe.grid.SingleGrid
 import wannabe.grid.TranslateGrid
 import wannabe.grid.VisibilityGrid
 import wannabe.projection.Projection
@@ -50,6 +52,9 @@ object SwingWannabe {
   private val playerGridVisibility =
     VisibilityGrid("Player Visibility", playerGridTranslate)
   private var movingPlayer = false
+  
+  // Cursor pick stuff
+  private val pickGrid = SingleGrid("Cursor")
 
   // Rotating stuff
   private var rotateGrid: RotateGrid? = null
@@ -59,6 +64,7 @@ object SwingWannabe {
   @Throws(InterruptedException::class) @JvmStatic
   fun main(args: Array<String>) {
     val frame = JFrame("SwingWannabe")
+    frame.setLocation(20, 30)
     frame.defaultCloseOperation = JFrame.EXIT_ON_CLOSE
     val mainLayout = JPanel(BorderLayout())
     frame.contentPane = mainLayout
@@ -100,6 +106,7 @@ object SwingWannabe {
       gridToRot[grid] = rot
     }
     allGrids.add(playerGridVisibility)
+    allGrids.add(pickGrid)
     playerGridVisibility.hide()
     // Show the first grid:
     currentGrid = SwingGrids.GRIDS[0]
@@ -191,10 +198,16 @@ object SwingWannabe {
       }
     })
     panel.addMouseMotionListener(object : MouseMotionAdapter() {
+      override fun mouseMoved(e: MouseEvent) {
+        val pos = panel.positionAtPixel(e.x, e.y)
+        // We effectively capture the picked voxel here, and then use it
+        // below for the rotation offset.
+        pickGrid.voxel = Voxel(pos, 0xFFFFFF)
+      }
       override fun mouseDragged(e: MouseEvent) {
         // Odd ordering here is just because it looks best, since most content is down-right of origin
         rotateGrid!!.setRotate(
-            e.y - startDragY, startDragX - e.x, 0
+            e.y - startDragY, startDragX - e.x, 0, pickGrid.voxel.position
         )
       }
     })


### PR DESCRIPTION
Doc cleanup, add SingleGrid.  Adds the ability to pick a certain voxel on screen by a reverse-lookup
with mouse coordinates.  Adds the ability to provide a custom center-point for rotation operations.
Using these two things, you can now rotate the current grid in the sample app about the point selected.